### PR TITLE
Update config system

### DIFF
--- a/assets/js/prosemirror/blocks.js
+++ b/assets/js/prosemirror/blocks.js
@@ -8,6 +8,8 @@ const blocks = {
   image: nodes.image
 };
 
+const allowedHeading = {h1: 1, h2: 2, h3: 3, h4: 4, h5: 5, h6: 6};
+
 function extractHeading({ heading }) {
   return {
     attrs: {level: {default: 1}},
@@ -28,13 +30,16 @@ export default (options) => {
     doc: blocks.doc
   };
 
+  const heading = [];
+
   jsonOptions.map((option) => {
-    if (typeof(option) == 'object') {
-      map['heading'] = extractHeading(option);
-    } else {
+    if (allowedHeading[option]) {
+      heading.push(allowedHeading[option]);
+    } else
       map[option] = blocks[option];
-    }
   });
+
+  map['heading'] = extractHeading({ heading });
 
   return map;
 };

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,29 @@
+use Mix.Config
+
+config :ex_prosemirror,
+  debug: false,
+  default: [
+    blocks: [:p, :h1, :h2]
+  ]
+
+if Mix.env() == :test do
+  config :ex_prosemirror,
+    default: [
+      blocks: [:p, :h1, :h2]
+    ],
+    types: [
+      title: [
+        marks: [:strong],
+        blocks: [:h1, :h2]
+      ],
+      lead: [],
+      sublead: [
+        marks: [:em],
+        blocks: [:h2, :h3]
+      ],
+      empty: [
+        marks: [],
+        blocks: []
+      ]
+    ]
+end

--- a/lib/ex_prosemirror/config.ex
+++ b/lib/ex_prosemirror/config.ex
@@ -1,0 +1,133 @@
+defmodule ExProsemirror.Config do
+  @moduledoc ~S"""
+  ExProsemirror allows an extensible configuration system.
+
+  You could generate multiples types of configuration depending on your needs.
+
+  E.g.
+
+      config :ex_prosemirror,
+        types: [
+          title: [blocks: [:h1], marks: []],
+          subtitle: [blocks: [:h2, :h3]]
+        ]
+
+  This will create 2 customs types:
+
+  - `title` that allows only `h1` block without any marks
+  - `subtitle` that allows `h2` and `h3` blocks and use default marks.
+
+  If there is no default configuration, then everything is allowed.
+
+  To override `default`, you can add a `default` config for `ex_prosemirror`.
+
+  E.g
+
+      config :ex_prosemirror,
+        default: [
+          marks: [:em],
+          blocks: [:p, :h1]
+        ]
+
+  This will set default marks to `em` only and `blocks` to `p` and `h1`.
+  """
+
+  require Logger
+
+  @default_marks ~w(em strong)a
+  @default_blocks ~w(p h1 h2 h3 h4 h5 h6 image)a
+
+  @doc ~S"""
+  Override the `config` with the `input_config`.
+
+  ## Examples
+
+      iex> ExProsemirror.Config.override([marks: []], [marks: [em: true]])
+      [marks: [:em]]
+
+      iex> ExProsemirror.Config.override([marks: [:em]], [marks: [em: true]])
+      [marks: [:em]]
+
+      iex> ExProsemirror.Config.override([marks: [:strong]], [marks: [em: true]])
+      [marks: [:em, :strong]]
+  """
+  def override(config, input_config) do
+    config
+    |> do_override(input_config, :marks)
+    |> do_override(input_config, :blocks)
+  end
+
+  defp do_override(config, input_config, field) do
+    if curr_config = Keyword.get(config, field) do
+      curr_config = do_override_reduce(curr_config, input_config, field)
+      Keyword.put(config, field, curr_config)
+    else
+      config
+    end
+  end
+
+  defp do_override_reduce(curr_config, input_config, field) do
+    input_config
+    |> Keyword.get(field, [])
+    |> List.flatten()
+    |> Enum.reduce(MapSet.new(curr_config), fn {field_type, enabled}, config ->
+      action = (enabled && :put) || :delete
+      Kernel.apply(MapSet, action, [config, field_type])
+    end)
+    |> MapSet.to_list()
+  end
+
+  @doc ~S"""
+  Get the configuration of ExProsemirror
+  """
+  def load do
+    Application.get_env(:ex_prosemirror, :types, [])
+  end
+
+  @doc ~S"""
+  Get the configuration for the specified type.
+
+  ## Examples
+
+      iex> ExProsemirror.Config.load(:title)
+      [blocks: [:h1, :h2], marks: [:strong]]
+
+      iex> ExProsemirror.Config.load(:lead)
+      [blocks: [:h1, :h2, :p], marks: [:em, :strong]]
+
+      iex> ExProsemirror.Config.load(:lead, marks: [em: false])
+      [blocks: [:h1, :h2, :p], marks: [:strong]]
+
+  """
+  def load(type, custom_config \\ [])
+
+  def load(:default, custom_config) do
+    put_default_types()
+    |> override(custom_config)
+  end
+
+  def load(type, custom_config) do
+    if config_type = Keyword.get(load(), type) do
+      put_default_types(config_type)
+    else
+      Logger.warn(fn ->
+        "ExProsemirror - Type \"#{type}\" not found in your configuration, using default."
+      end)
+
+      put_default_types()
+    end
+    |> override(custom_config)
+  end
+
+  def debug?, do: Application.get_env(:ex_prosemirror, :debug, false)
+
+  defp put_default_types(opts \\ default()) do
+    opts
+    |> Keyword.put_new(:marks, default_marks())
+    |> Keyword.put_new(:blocks, default_blocks())
+  end
+
+  defp default, do: Application.get_env(:ex_prosemirror, :default, [])
+  defp default_marks, do: default() |> Keyword.get(:marks, @default_marks)
+  defp default_blocks, do: default() |> Keyword.get(:blocks, @default_blocks)
+end

--- a/lib/ex_prosemirror/html/form.ex
+++ b/lib/ex_prosemirror/html/form.ex
@@ -72,7 +72,7 @@ defmodule ExProsemirror.HTML.Form do
       |> Keyword.put(:phx_update, "ignore")
       |> Keyword.update(:id, "#{field}_plain", fn id -> "#{id}_plain" end)
 
-    if Application.get_env(:ex_prosemirror, :debug, false) do
+    if ExProsemirror.Config.debug?() do
       textarea(form, :"#{field}_plain", opts)
     else
       hidden_input(form, :"#{field}_plain", opts)
@@ -98,16 +98,21 @@ defmodule ExProsemirror.HTML.Form do
       |> Keyword.put_new(:class, "ex-prosemirror")
       |> Keyword.put(:phx_update, "ignore")
       |> Keyword.put(:phx_hook, "MountProseMirror")
+      |> Keyword.put_new(:type, :default)
       |> Keyword.put_new(:name, input_name(form, field))
 
+    # TODO  reduce function complexity
+    {type, opts} = Keyword.pop(opts, :type)
     {marks, opts} = Keyword.pop_values(opts, :marks)
     {blocks, opts} = Keyword.pop_values(opts, :blocks)
     {data, opts} = Keyword.pop_values(opts, :data)
 
+    config = ExProsemirror.Config.load(type, marks: marks, blocks: blocks)
+
     data =
       data
-      |> Keyword.put(:marks, to_html_data(marks))
-      |> Keyword.put(:blocks, to_html_data(blocks))
+      |> Keyword.put(:marks, config |> Keyword.get_values(:marks) |> to_html_data())
+      |> Keyword.put(:blocks, config |> Keyword.get_values(:blocks) |> to_html_data())
       |> Keyword.put(:target, "##{Keyword.get(opts, :id)}")
 
     {_value, opts} = Keyword.pop(opts, :value, input_value(form, field))

--- a/test/ex_prosemirror_test.exs
+++ b/test/ex_prosemirror_test.exs
@@ -1,6 +1,7 @@
 defmodule ExProsemirrorTest do
   use ExUnit.Case
   doctest ExProsemirror
+  doctest ExProsemirror.Config
 
   import Phoenix.HTML.Safe
 

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -10,7 +10,7 @@ defmodule ExProsemirror.FormTest do
     test "without value" do
       input_html =
         %Form{data: %{}}
-        |> prosemirror_hidden_input(:title)
+        |> prosemirror_hidden_input(:title, type: :empty)
         |> safe_to_string()
 
       assert input_html =~
@@ -20,7 +20,7 @@ defmodule ExProsemirror.FormTest do
     test "with value" do
       input_html =
         %Form{data: %{title_plain: "hello"}}
-        |> prosemirror_hidden_input(:title)
+        |> prosemirror_hidden_input(:title, type: :empty)
         |> safe_to_string()
 
       assert input_html =~
@@ -32,7 +32,7 @@ defmodule ExProsemirror.FormTest do
     test "without opts" do
       input_html =
         %Form{data: %{title_plain: "hello"}}
-        |> prosemirror_editor(:title)
+        |> prosemirror_editor(:title, type: :empty)
         |> safe_to_string()
 
       assert input_html =~
@@ -42,7 +42,7 @@ defmodule ExProsemirror.FormTest do
     test "with one mark" do
       input_html =
         %Form{data: %{title_plain: "hello"}}
-        |> prosemirror_editor(:title, marks: [:em])
+        |> prosemirror_editor(:title, type: :empty, marks: [em: true])
         |> safe_to_string()
 
       assert input_html =~
@@ -52,11 +52,31 @@ defmodule ExProsemirror.FormTest do
     test "with 2 marks" do
       input_html =
         %Form{data: %{title_plain: "hello"}}
-        |> prosemirror_editor(:title, marks: [:em, :strong])
+        |> prosemirror_editor(:title, type: :empty, marks: [em: true, strong: true])
         |> safe_to_string()
 
       assert input_html =~
                ~s(data-marks="[&quot;em&quot;,&quot;strong&quot;]")
+    end
+
+    test "with p block" do
+      input_html =
+        %Form{data: %{title_plain: "hello"}}
+        |> prosemirror_editor(:title, type: :empty, blocks: [p: true])
+        |> safe_to_string()
+
+      assert input_html =~
+               ~s(data-blocks="[&quot;p&quot;]")
+    end
+
+    test "with h1 and p block" do
+      input_html =
+        %Form{data: %{title_plain: "hello"}}
+        |> prosemirror_editor(:title, type: :empty, blocks: [p: true, h1: true])
+        |> safe_to_string()
+
+      assert input_html =~
+               ~s(data-blocks="[&quot;h1&quot;,&quot;p&quot;]")
     end
   end
 
@@ -66,7 +86,7 @@ defmodule ExProsemirror.FormTest do
 
       inputs_html =
         form
-        |> ExProsemirror.HTML.Form.prosemirror_input(:title)
+        |> ExProsemirror.HTML.Form.prosemirror_input(:title, type: :empty)
         |> Phoenix.HTML.safe_to_string()
 
       hidden_input_html =
@@ -76,7 +96,7 @@ defmodule ExProsemirror.FormTest do
 
       editor_input_html =
         form
-        |> prosemirror_editor(:title)
+        |> prosemirror_editor(:title, type: :empty)
         |> safe_to_string()
 
       assert inputs_html =~ hidden_input_html


### PR DESCRIPTION
## 📖 Description

Add custom config system to define a `type` of `prosemirror_input`

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Close #19 

## 📋 Type of change

<!-- Please delete options that are not relevant  -->

- [x] Breaking change : change the `prosemirror_input` opts (change `heading: [1, 2]` to `[:h1, :h2...]`
- [x] This change requires a documentation update (need regenerate the docs)
