### PR TITLE
Add underline mark (JS)

### DIFF
--- a/assets/js/prosemirror/icons.js
+++ b/assets/js/prosemirror/icons.js
@@ -1,0 +1,10 @@
+import { icons as prosemirrorIcons } from 'prosemirror-menu';
+
+export const icons = {
+  ...prosemirrorIcons,
+  underline: {
+    'width': 22,
+    'height': 20,
+    'path': 'M16 5c.6 0 1 .4 1 1v5.5a4 4 0 01-.4 1.8l-1 1.4a5.3 5.3 0 01-5.5 1a5 5 0 01-1.6-1c-.5-.4-.8-.9-1.1-1.4a4 4 0 01-.4-1.8V6c0-.6.4-1 1-1s1 .4 1 1v5.5c0 .3 0 .6.2 1l.6.7a3.3 3.3 0 002.2.8a3.4 3.4 0 002.2-.8c.3-.2.4-.5.6-.8l.2-.9V6c0-.6.4-1 1-1zM8 17h8c.6 0 1 .4 1 1s-.4 1-1 1H8a1 1 0 010-2z'
+  }
+};

--- a/assets/js/prosemirror/marks.js
+++ b/assets/js/prosemirror/marks.js
@@ -4,7 +4,11 @@ import { MenuItem } from 'prosemirror-menu';
 
 const marks = {
   strong: prosemirrorMarks.strong,
-  em: prosemirrorMarks.em
+  em: prosemirrorMarks.em,
+  underline: {
+    toDOM() { return ['span', {style: 'text-decoration: underline'}, 0]; },
+    parseDOM: [{tag: 'span' }]
+  },
 };
 
 /**

--- a/assets/js/prosemirror/menu.js
+++ b/assets/js/prosemirror/menu.js
@@ -1,4 +1,5 @@
-import { Dropdown, MenuItem, menuBar, icons, blockTypeItem } from 'prosemirror-menu';
+import { Dropdown, MenuItem, menuBar, blockTypeItem } from 'prosemirror-menu';
+import { icons } from './icons';
 import { markItem } from './marks';
 
 function generateHeadingItem(schema) {

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,12 +2,13 @@ use Mix.Config
 
 config :ex_prosemirror,
   debug: false,
-  default: [
-    blocks: [:p, :h1, :h2]
-  ]
+  default_blocks: [:p, :h1, :h2, :h3, :h4, :h5, :h6, :image],
+  default_marks: [:em, :strong, :underline]
 
 if Mix.env() == :test do
   config :ex_prosemirror,
+    default_blocks: [:p, :h1, :h2],
+    default_marks: [:em, :strong],
     default: [
       blocks: [:p, :h1, :h2]
     ],

--- a/lib/ex_prosemirror/config.ex
+++ b/lib/ex_prosemirror/config.ex
@@ -34,8 +34,9 @@ defmodule ExProsemirror.Config do
 
   require Logger
 
-  @default_marks ~w(em strong underline)a
-  @default_blocks ~w(p h1 h2 h3 h4 h5 h6 image)a
+  @default_marks Application.compile_env!(:ex_prosemirror, :default_marks)
+  @default_blocks Application.compile_env!(:ex_prosemirror, :default_blocks)
+  @default [blocks: @default_blocks, marks: @default_marks]
 
   @doc ~S"""
   Override the `config` with the `input_config`.
@@ -121,13 +122,9 @@ defmodule ExProsemirror.Config do
 
   def debug?, do: Application.get_env(:ex_prosemirror, :debug, false)
 
-  defp put_default_types(opts \\ default()) do
+  defp put_default_types(opts \\ @default) do
     opts
-    |> Keyword.put_new(:marks, default_marks())
-    |> Keyword.put_new(:blocks, default_blocks())
+    |> Keyword.put_new(:marks, @default_marks)
+    |> Keyword.put_new(:blocks, @default_blocks)
   end
-
-  defp default, do: Application.get_env(:ex_prosemirror, :default, [])
-  defp default_marks, do: default() |> Keyword.get(:marks, @default_marks)
-  defp default_blocks, do: default() |> Keyword.get(:blocks, @default_blocks)
 end

--- a/lib/ex_prosemirror/config.ex
+++ b/lib/ex_prosemirror/config.ex
@@ -34,7 +34,7 @@ defmodule ExProsemirror.Config do
 
   require Logger
 
-  @default_marks ~w(em strong)a
+  @default_marks ~w(em strong underline)a
   @default_blocks ~w(p h1 h2 h3 h4 h5 h6 image)a
 
   @doc ~S"""


### PR DESCRIPTION
## 📖 Description

This PR adds a new mark to the catalogue.

More about the underline mark:
it wraps your selection with a `<span>` with applied styles `text-decoration: underline`

It works the same as all other makes with toggling and stuff like that.

#### Extra

I moved the default node config into our `config/config.exs`, that way in the future we shouldn't need to touch the `ex_prosemirror/config.ex` file.

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

References #29 

## 📋 Type of change

<!-- Please delete options that are not relevant  -->

- [x] New feature (non-breaking change which adds functionality)

## Screenshot 📸
<img width="798" alt="Screen Shot 2021-06-03 at 12 16 23 PM" src="https://user-images.githubusercontent.com/20251602/120684575-d856a080-c46c-11eb-894f-7c13e735ce60.png">

