### PR TITLE
Add inline option to prosemirror_input

### DIFF
--- a/assets/js/ExEditorView.js
+++ b/assets/js/ExEditorView.js
@@ -7,7 +7,6 @@ import { DOMParser } from 'prosemirror-model';
 import schemaFunc from './prosemirror/schema';
 import { placeholderPlugin, insertPlaceholder } from './prosemirror/plugins/placeholder';
 
-
 export default class ExEditorView {
   /**
    * @param {HTMLElement} editorNode
@@ -19,16 +18,19 @@ export default class ExEditorView {
 
     this.editorView = new EditorView(editorNode, {
       state: this.initializeEditorState(opts),
-      dispatchTransaction: (transaction) => {this.dispatchTransaction(transaction);},
+      dispatchTransaction: (transaction) => {
+        this.dispatchTransaction(transaction);
+      }
     });
 
     this.addListeners();
   }
 
-  initializeEditorState({customBlocks, customMarks}) {
+  initializeEditorState({ customBlocks, customMarks }) {
     const opts = {
       marksSelection: JSON.parse(this.editorNode.dataset.marks),
       blocksSelection: JSON.parse(this.editorNode.dataset.blocks),
+      inline: JSON.parse(this.editorNode.dataset.inline),
       customBlocks,
       customMarks
     };
@@ -44,7 +46,7 @@ export default class ExEditorView {
   getDoc(schema) {
     const initialValue = document.querySelector(this.target).value;
 
-    if(initialValue.length > 0) {
+    if (initialValue.length > 0) {
       try {
         return schema.nodeFromJSON(JSON.parse(initialValue));
       } catch {

--- a/assets/js/prosemirror/blocks.js
+++ b/assets/js/prosemirror/blocks.js
@@ -25,12 +25,13 @@ function extractHeading({ heading }) {
 }
 
 function inlineDoc(inline) {
-  return inline == 'true' ? { content: 'block?' } : blocks.doc;
+  return inline ? { content: 'block?' } : prosemirrorBlocks.doc;
 }
 
 /**
  * @param {Object} blocksSelection
  * @param {Object[]} customBlocks
+ * @param {Boolean} inline
  */
 export default (blocksSelection, customBlocks) => {
   const blocks = { ...prosemirrorBlocks, custom: customBlocks || [] };

--- a/assets/js/prosemirror/blocks.js
+++ b/assets/js/prosemirror/blocks.js
@@ -33,7 +33,7 @@ function inlineDoc(inline) {
  * @param {Object[]} customBlocks
  * @param {Boolean} inline
  */
-export default (blocksSelection, customBlocks) => {
+export default ({ blocksSelection, customBlocks, inline }) => {
   const blocks = { ...prosemirrorBlocks, custom: customBlocks || [] };
 
   const map = {

--- a/assets/js/prosemirror/blocks.js
+++ b/assets/js/prosemirror/blocks.js
@@ -8,18 +8,24 @@ const prosemirrorBlocks = {
   image: nodes.image
 };
 
-const allowedHeading = {h1: 1, h2: 2, h3: 3, h4: 4, h5: 5, h6: 6};
+const allowedHeading = { h1: 1, h2: 2, h3: 3, h4: 4, h5: 5, h6: 6 };
 
 function extractHeading({ heading }) {
   return {
-    attrs: {level: {default: 1}},
+    attrs: { level: { default: 1 } },
     allowsLevel: heading,
     content: 'inline*',
     group: 'block',
     defining: true,
-    parseDOM: heading.map((header) => ({tag: 'h' + header, attrs: {level: header}})),
-    toDOM(node) { return ['h' + node.attrs.level, 0]; }
+    parseDOM: heading.map((header) => ({ tag: 'h' + header, attrs: { level: header } })),
+    toDOM(node) {
+      return ['h' + node.attrs.level, 0];
+    }
   };
+}
+
+function inlineDoc(inline) {
+  return inline == 'true' ? { content: 'block?' } : blocks.doc;
 }
 
 /**
@@ -27,11 +33,11 @@ function extractHeading({ heading }) {
  * @param {Object[]} customBlocks
  */
 export default (blocksSelection, customBlocks) => {
-  const blocks = {...prosemirrorBlocks, custom: customBlocks || []};
+  const blocks = { ...prosemirrorBlocks, custom: customBlocks || [] };
 
   const map = {
     text: blocks.text,
-    doc: blocks.doc
+    doc: inlineDoc(inline)
   };
 
   const heading = [];
@@ -39,9 +45,9 @@ export default (blocksSelection, customBlocks) => {
   blocksSelection.map((/** @type {Object} */ blockSelection) => {
     if (allowedHeading[blockSelection]) {
       heading.push(allowedHeading[blockSelection]);
-    } else if(blocks[blockSelection]) {
+    } else if (blocks[blockSelection]) {
       map[blockSelection] = blocks[blockSelection];
-    } else if(blocks.custom[blockSelection]){
+    } else if (blocks.custom[blockSelection]) {
       map['custom_block_' + blockSelection] = blocks.custom[blockSelection];
     }
   });

--- a/assets/js/prosemirror/marks.js
+++ b/assets/js/prosemirror/marks.js
@@ -6,9 +6,11 @@ const exProsemirrorMarks = {
   strong: prosemirrorMarks.strong,
   em: prosemirrorMarks.em,
   underline: {
-    toDOM() { return ['span', {style: 'text-decoration: underline'}, 0]; },
-    parseDOM: [{tag: 'span' }]
-  },
+    toDOM() {
+      return ['span', { style: 'text-decoration: underline' }, 0];
+    },
+    parseDOM: [{ tag: 'span' }]
+  }
 };
 
 /**
@@ -16,15 +18,15 @@ const exProsemirrorMarks = {
  * @param {Object} marksSelection
  * @param {Object[]} customMarks
  */
-export const generateSchemaMarks = (marksSelection, customMarks) => {
-  const marks = {...exProsemirrorMarks, custom: customMarks || []};
+export const generateSchemaMarks = ({ marksSelection, customMarks }) => {
+  const marks = { ...exProsemirrorMarks, custom: customMarks || [] };
 
   const result = {};
 
   marksSelection.map((/** @type {Object} */ selection) => {
     if (marks[selection]) {
       result[selection] = marks[selection];
-    } else if(marks.custom[selection]){
+    } else if (marks.custom[selection]) {
       result['custom_mark_' + selection] = marks.custom[selection];
     }
   });
@@ -40,7 +42,9 @@ export const generateSchemaMarks = (marksSelection, customMarks) => {
  */
 export function markItem(markType, options) {
   let passedOptions = {
-    active(state) { return markActive(state, markType); },
+    active(state) {
+      return markActive(state, markType);
+    },
     enable: true
   };
 
@@ -55,7 +59,7 @@ export function markItem(markType, options) {
  * @param {any} type - Mark's type
  */
 export function markActive(state, type) {
-  let {from, $from, to, empty} = state.selection;
+  let { from, $from, to, empty } = state.selection;
   if (empty) return type.isInSet(state.storedMarks || $from.marks());
   else return state.doc.rangeHasMark(from, to, type);
 }
@@ -73,7 +77,7 @@ export function cmdItem(cmd, options) {
   };
   for (let prop in options) passedOptions[prop] = options[prop];
   if ((!options.enable || options.enable === true) && !options.select)
-    passedOptions[options.enable ? 'enable' : 'select'] = state => cmd(state);
+    passedOptions[options.enable ? 'enable' : 'select'] = (state) => cmd(state);
 
   return new MenuItem(passedOptions);
 }

--- a/assets/js/prosemirror/schema.js
+++ b/assets/js/prosemirror/schema.js
@@ -3,7 +3,7 @@ import { generateSchemaMarks } from './marks';
 import blocks from './blocks';
 
 /**
- * @param {{customBlocks: Object[], customMarks: Object[], blocksSelection: JSON, marksSelection: JSON}} options
+ * @param {{customBlocks: Object[], customMarks: Object[], blocksSelection: JSON, marksSelection: JSON, inline: Boolean}} options
  */
 export default (options) =>
   new Schema({

--- a/assets/js/prosemirror/schema.js
+++ b/assets/js/prosemirror/schema.js
@@ -5,9 +5,8 @@ import blocks from './blocks';
 /**
  * @param {{customBlocks: Object[], customMarks: Object[], blocksSelection: JSON, marksSelection: JSON}} options
  */
-export default (options) => (
+export default (options) =>
   new Schema({
     nodes: blocks(options.blocksSelection, options.customBlocks),
-    marks: generateSchemaMarks(options.marksSelection, options.customMarks),
-  })
-);
+    marks: generateSchemaMarks(options.marksSelection, options.customMarks)
+  });

--- a/assets/js/prosemirror/schema.js
+++ b/assets/js/prosemirror/schema.js
@@ -7,6 +7,6 @@ import blocks from './blocks';
  */
 export default (options) =>
   new Schema({
-    nodes: blocks(options.blocksSelection, options.customBlocks),
-    marks: generateSchemaMarks(options.marksSelection, options.customMarks)
+    nodes: blocks(options),
+    marks: generateSchemaMarks(options)
   });

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,12 +3,14 @@ use Mix.Config
 config :ex_prosemirror,
   debug: false,
   default_blocks: [:p, :h1, :h2, :h3, :h4, :h5, :h6, :image],
-  default_marks: [:em, :strong, :underline]
+  default_marks: [:em, :strong, :underline],
+  default_inline: false
 
 if Mix.env() == :test do
   config :ex_prosemirror,
     default_blocks: [:p, :h1, :h2],
     default_marks: [:em, :strong],
+    default_inline: false,
     default: [
       blocks: [:p, :h1, :h2]
     ],

--- a/lib/ex_prosemirror/config.ex
+++ b/lib/ex_prosemirror/config.ex
@@ -36,8 +36,8 @@ defmodule ExProsemirror.Config do
 
   @default_marks Application.compile_env!(:ex_prosemirror, :default_marks)
   @default_blocks Application.compile_env!(:ex_prosemirror, :default_blocks)
+  @default_inline Application.compile_env!(:ex_prosemirror, :default_inline)
   @default [blocks: @default_blocks, marks: @default_marks]
-  @default_inline false
 
   @doc ~S"""
   Override the `config` with the `input_config`.
@@ -61,9 +61,11 @@ defmodule ExProsemirror.Config do
   end
 
   defp do_override(config, input_config, :inline) do
-    if is_nil(Keyword.get(input_config, :inline)),
+    inline? = Keyword.get(input_config, :inline)
+
+    if is_nil(inline?),
       do: config,
-      else: Keyword.put(config, :inline, Keyword.get(input_config, :inline))
+      else: Keyword.put(config, :inline, inline?)
   end
 
   defp do_override(config, input_config, field) do
@@ -99,13 +101,13 @@ defmodule ExProsemirror.Config do
   ## Examples
 
       iex> ExProsemirror.Config.load(:title)
-      [blocks: [:h1, :h2], marks: [:strong]]
+      [blocks: [:h1, :h2], marks: [:strong], inline: false]
 
       iex> ExProsemirror.Config.load(:lead)
-      [blocks: [:h1, :h2, :p], marks: [:em, :strong]]
+      [blocks: [:h1, :h2, :p], marks: [:em, :strong], inline: false]
 
       iex> ExProsemirror.Config.load(:lead, marks: [em: false])
-      [blocks: [:h1, :h2, :p], marks: [:strong]]
+      [blocks: [:h1, :h2, :p], marks: [:strong], inline: false]
 
   """
   def load(type, custom_config \\ [])

--- a/lib/ex_prosemirror/config.ex
+++ b/lib/ex_prosemirror/config.ex
@@ -37,6 +37,7 @@ defmodule ExProsemirror.Config do
   @default_marks Application.compile_env!(:ex_prosemirror, :default_marks)
   @default_blocks Application.compile_env!(:ex_prosemirror, :default_blocks)
   @default [blocks: @default_blocks, marks: @default_marks]
+  @default_inline false
 
   @doc ~S"""
   Override the `config` with the `input_config`.
@@ -56,6 +57,13 @@ defmodule ExProsemirror.Config do
     config
     |> do_override(input_config, :marks)
     |> do_override(input_config, :blocks)
+    |> do_override(input_config, :inline)
+  end
+
+  defp do_override(config, input_config, :inline) do
+    if is_nil(Keyword.get(input_config, :inline)),
+      do: config,
+      else: Keyword.put(config, :inline, Keyword.get(input_config, :inline))
   end
 
   defp do_override(config, input_config, field) do

--- a/lib/ex_prosemirror/config.ex
+++ b/lib/ex_prosemirror/config.ex
@@ -136,5 +136,6 @@ defmodule ExProsemirror.Config do
     opts
     |> Keyword.put_new(:marks, @default_marks)
     |> Keyword.put_new(:blocks, @default_blocks)
+    |> Keyword.put_new(:inline, @default_inline)
   end
 end

--- a/lib/ex_prosemirror/html/form.ex
+++ b/lib/ex_prosemirror/html/form.ex
@@ -110,14 +110,16 @@ defmodule ExProsemirror.HTML.Form do
     {type, opts} = Keyword.pop(opts, :type)
     {marks, opts} = Keyword.pop_values(opts, :marks)
     {blocks, opts} = Keyword.pop_values(opts, :blocks)
+    {inline, opts} = Keyword.pop(opts, :inline)
     {data, opts} = Keyword.pop_values(opts, :data)
 
-    config = ExProsemirror.Config.load(type, marks: marks, blocks: blocks)
+    config = ExProsemirror.Config.load(type, marks: marks, blocks: blocks, inline: inline)
 
     data =
       data
       |> Keyword.put(:marks, config |> Keyword.get_values(:marks) |> to_html_data())
       |> Keyword.put(:blocks, config |> Keyword.get_values(:blocks) |> to_html_data())
+      |> Keyword.put(:inline, config |> Keyword.get(:inline) |> to_html_data())
       |> Keyword.put(:target, "##{Keyword.get(opts, :id)}")
 
     {_value, opts} = Keyword.pop(opts, :value, input_value(form, field))

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -36,7 +36,7 @@ defmodule ExProsemirror.FormTest do
         |> safe_to_string()
 
       assert input_html =~
-               ~s(<div class="ex-prosemirror" data-blocks="[]" data-marks="[]" data-target="#title" id="title")
+               ~s(<div class="ex-prosemirror" data-blocks="[]" data-inline="false" data-marks="[]" data-target="#title" id="title")
     end
 
     test "with one mark" do


### PR DESCRIPTION
## 📖 Description

Adds the ability to make inline inputs with `prosemirror_input`, 
the inline input only allows one block per input 

Fixes #14 

## 📋 Type of change

<!-- Please delete options that are not relevant  -->

- [x] Add inline option to html input
- [x] change the `doc` `content` config to include 0 or 1 block
