### PR TITLE
Add html encoder for block and marks

### DIFF
--- a/lib/ex_prosemirror/block/heading.ex
+++ b/lib/ex_prosemirror/block/heading.ex
@@ -20,6 +20,7 @@ defmodule ExProsemirror.Block.Heading do
   import Ecto.Changeset
 
   alias ExProsemirror.Block.Text
+  alias ExProsemirror.Encoder.HTML, as: HTMLEncoder
 
   @type t :: %__MODULE__{
           attrs: %__MODULE__.Attrs{level: attrs_level},
@@ -40,6 +41,15 @@ defmodule ExProsemirror.Block.Heading do
     |> cast(attrs, [])
     |> cast_embed(:attrs, required: true)
     |> cast_prosemirror_content(with: [text: {Text, :changeset, [opts]}])
+  end
+
+  defimpl HTMLEncoder do
+    import Phoenix.HTML.Tag
+
+    def encode(struct, _opts) do
+      tag = "h#{struct.attrs.level}"
+      content_tag(tag, HTMLEncoder.encode(struct.content))
+    end
   end
 
   defmodule __MODULE__.Attrs do

--- a/lib/ex_prosemirror/block/html.ex
+++ b/lib/ex_prosemirror/block/html.ex
@@ -50,6 +50,12 @@ defmodule ExProsemirror.Block.HTML do
     |> cast_embed(:attrs, required: true)
   end
 
+  defimpl ExProsemirror.Encoder.HTML do
+    def encode(%{attrs: %{html: html}}, _inner_content) do
+      {:safe, html}
+    end
+  end
+
   defmodule __MODULE__.Attrs do
     @derive {Jason.Encoder, except: [:__struct__]}
     @moduledoc false

--- a/lib/ex_prosemirror/block/image.ex
+++ b/lib/ex_prosemirror/block/image.ex
@@ -54,6 +54,14 @@ defmodule ExProsemirror.Block.Image do
     |> cast_embed(:attrs, required: true)
   end
 
+  defimpl ExProsemirror.Encoder.HTML do
+    import Phoenix.HTML.Tag, only: [tag: 2]
+
+    def encode(%{attrs: attrs}, _opts) do
+      tag("img", src: attrs.src, alt: attrs.alt)
+    end
+  end
+
   defmodule __MODULE__.Attrs do
     @derive {Jason.Encoder, except: [:__struct__]}
     @moduledoc false

--- a/lib/ex_prosemirror/block/paragraph.ex
+++ b/lib/ex_prosemirror/block/paragraph.ex
@@ -9,6 +9,7 @@ defmodule ExProsemirror.Block.Paragraph do
   import Ecto.Changeset
 
   alias ExProsemirror.Block.Text
+  alias ExProsemirror.Encoder.HTML, as: HTMLEncoder
 
   @type t :: %__MODULE__{
           content: [Text.t()]
@@ -28,5 +29,13 @@ defmodule ExProsemirror.Block.Paragraph do
 
   def extract_simple_text(struct) do
     Enum.map(struct.content, &ExProsemirror.extract_simple_text/1)
+  end
+
+  defimpl HTMLEncoder do
+    import Phoenix.HTML.Tag, only: [content_tag: 2]
+
+    def encode(struct, _opts) do
+      content_tag("p", HTMLEncoder.encode(struct.content))
+    end
   end
 end

--- a/lib/ex_prosemirror/block/text.ex
+++ b/lib/ex_prosemirror/block/text.ex
@@ -18,6 +18,8 @@ defmodule ExProsemirror.Block.Text do
 
   import Ecto.Changeset
 
+  alias ExProsemirror.Encoder.HTML, as: HTMLEncoder
+
   @type t :: %__MODULE__{
           text: String.t(),
           marks: [Strong.t() | Em.t() | Underline.t()]
@@ -58,4 +60,16 @@ defmodule ExProsemirror.Block.Text do
       "Hello elixir's friends"
   """
   def extract_simple_text(%__MODULE__{text: text}), do: text
+
+  defimpl HTMLEncoder do
+    def encode(struct, _opts) do
+      text = Phoenix.HTML.html_escape(struct.text)
+
+      struct.marks
+      |> Enum.reverse()
+      |> Enum.reduce(text, fn mark, acc ->
+        HTMLEncoder.encode(mark, inner_content: acc)
+      end)
+    end
+  end
 end

--- a/lib/ex_prosemirror/encoder/html.ex
+++ b/lib/ex_prosemirror/encoder/html.ex
@@ -1,0 +1,37 @@
+defprotocol ExProsemirror.Encoder.HTML do
+  @moduledoc ~S"""
+  HTML encoder protocol for ExProsemirror's struct.
+
+  ## Example of implementation
+
+      alias ExProsemirror.Encoder.HTML, as: HTMLEncoder
+
+      defimpl HTMLEncoder do
+        def encode(struct, _opts) do
+          text = Phoenix.HTML.html_escape(struct.text)
+
+          struct.marks
+          |> Enum.reverse()
+          |> Enum.reduce(text, fn mark, acc ->
+            HTMLEncoder.encode(mark, inner_content: acc)
+          end)
+        end
+
+  """
+
+  @doc ~S"""
+  Encode the struct to html content.
+
+  ## Options
+
+  - `inner_content`: element to put inside the encoded block / marks.
+  """
+
+  def encode(struct, opts \\ [])
+end
+
+defimpl ExProsemirror.Encoder.HTML, for: List do
+  def encode(structs, _opts) do
+    Enum.map(structs, &ExProsemirror.Encoder.HTML.encode/1)
+  end
+end

--- a/lib/ex_prosemirror/html.ex
+++ b/lib/ex_prosemirror/html.ex
@@ -1,0 +1,18 @@
+defmodule ExProsemirror.HTML do
+  @moduledoc ~S"""
+  HTML management of ex_prosemirror.
+  """
+
+  import Phoenix.HTML.Tag, only: [content_tag: 2]
+  import ExProsemirror.Encoder.HTML, only: [encode: 1]
+
+  @doc ~S"""
+  Render a type to an html element.
+  """
+  def html_safe(ex_prosemirror_type) do
+    content_tag(
+      :div,
+      encode(ex_prosemirror_type.content)
+    )
+  end
+end

--- a/lib/ex_prosemirror/mark/color.ex
+++ b/lib/ex_prosemirror/mark/color.ex
@@ -33,6 +33,14 @@ defmodule ExProsemirror.Mark.Color do
     |> cast_embed(:attrs)
   end
 
+  defimpl ExProsemirror.Encoder.HTML do
+    import Phoenix.HTML.Tag, only: [content_tag: 3]
+
+    def encode(struct, opts) do
+      content_tag(:span, opts[:inner_content], style: "color: #{struct.attrs.color};")
+    end
+  end
+
   defmodule __MODULE__.Attrs do
     @derive {Jason.Encoder, except: [:__struct__]}
     @moduledoc false

--- a/lib/ex_prosemirror/mark/em.ex
+++ b/lib/ex_prosemirror/mark/em.ex
@@ -15,4 +15,12 @@ defmodule ExProsemirror.Mark.Em do
   def changeset(struct_or_changeset, _attrs \\ %{}) do
     %Ecto.Changeset{valid?: true, data: struct_or_changeset}
   end
+
+  defimpl ExProsemirror.Encoder.HTML do
+    import Phoenix.HTML.Tag, only: [content_tag: 2]
+
+    def encode(_struct, opts) do
+      content_tag(:em, opts[:inner_content])
+    end
+  end
 end

--- a/lib/ex_prosemirror/mark/font_family.ex
+++ b/lib/ex_prosemirror/mark/font_family.ex
@@ -32,6 +32,16 @@ defmodule ExProsemirror.Mark.FontFamily do
     |> cast_embed(:attrs)
   end
 
+  defimpl ExProsemirror.Encoder.HTML do
+    import Phoenix.HTML.Tag, only: [content_tag: 3]
+
+    def encode(struct, opts) do
+      content_tag(:span, opts[:inner_content],
+        style: ~s(font-family: "#{struct.attrs.font_family};")
+      )
+    end
+  end
+
   defmodule __MODULE__.Attrs do
     @derive {Jason.Encoder, except: [:__struct__]}
     @moduledoc false

--- a/lib/ex_prosemirror/mark/link.ex
+++ b/lib/ex_prosemirror/mark/link.ex
@@ -64,6 +64,14 @@ defmodule ExProsemirror.Mark.Link do
     |> cast_embed(:attrs)
   end
 
+  defimpl ExProsemirror.Encoder.HTML do
+    import Phoenix.HTML.Tag, only: [content_tag: 3]
+
+    def encode(struct, opts) do
+      content_tag(:a, opts[:inner_content], href: struct.attrs.href)
+    end
+  end
+
   defmodule __MODULE__.Attrs do
     @derive {Jason.Encoder, except: [:__struct__]}
     @moduledoc false

--- a/lib/ex_prosemirror/mark/strikethrough.ex
+++ b/lib/ex_prosemirror/mark/strikethrough.ex
@@ -15,4 +15,12 @@ defmodule ExProsemirror.Mark.Strikethrough do
   def changeset(struct_or_changeset, _attrs \\ %{}) do
     %Ecto.Changeset{valid?: true, data: struct_or_changeset}
   end
+
+  defimpl ExProsemirror.Encoder.HTML do
+    import Phoenix.HTML.Tag, only: [content_tag: 2]
+
+    def encode(_struct, opts) do
+      content_tag(:del, opts[:inner_content])
+    end
+  end
 end

--- a/lib/ex_prosemirror/mark/strong.ex
+++ b/lib/ex_prosemirror/mark/strong.ex
@@ -20,4 +20,12 @@ defmodule ExProsemirror.Mark.Strong do
   def changeset(struct_or_changeset, _attrs \\ %{}) do
     %Ecto.Changeset{valid?: true, data: struct_or_changeset}
   end
+
+  defimpl ExProsemirror.Encoder.HTML do
+    import Phoenix.HTML.Tag, only: [content_tag: 2]
+
+    def encode(_struct, opts) do
+      content_tag(:strong, opts[:inner_content])
+    end
+  end
 end

--- a/lib/ex_prosemirror/mark/underline.ex
+++ b/lib/ex_prosemirror/mark/underline.ex
@@ -20,4 +20,12 @@ defmodule ExProsemirror.Mark.Underline do
   def changeset(struct_or_changeset, _attrs \\ %{}) do
     %Ecto.Changeset{valid?: true, data: struct_or_changeset}
   end
+
+  defimpl ExProsemirror.Encoder.HTML do
+    import Phoenix.HTML.Tag, only: [content_tag: 3]
+
+    def encode(_struct, opts) do
+      content_tag(:span, opts[:inner_content], style: "text-decoration: underline;")
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -37,9 +37,16 @@ defmodule ExProsemirror.MixProject do
       extras: ["guides/extends_editor.md"],
       groups_for_modules: [
         HTML: [ExProsemirror.HTML.Form],
+        Encoders: prosemirror_encoders(),
         Ecto: prosemirror_ecto_related(),
         Modifiers: prosemirror_modifiers()
       ]
+    ]
+  end
+
+  defp prosemirror_encoders do
+    [
+      ExProsemirror.Encoder.HTML
     ]
   end
 
@@ -55,6 +62,7 @@ defmodule ExProsemirror.MixProject do
       ExProsemirror.Block.HTML,
       ExProsemirror.Mark,
       ExProsemirror.Mark.Em,
+      ExProsemirror.Mark.Link,
       ExProsemirror.Mark.Strong,
       ExProsemirror.Mark.Underline,
       ExProsemirror.Mark.Strikethrough,

--- a/test/encoder/html_test.exs
+++ b/test/encoder/html_test.exs
@@ -1,0 +1,147 @@
+defmodule ExProsemirror.Encoder.HTMLTest do
+  @moduledoc false
+  use ExUnit.Case
+
+  import Phoenix.HTML
+
+  alias ExProsemirror.Block.{Heading, Image, Paragraph, Text}
+  alias ExProsemirror.Encoder.HTML, as: HTMLEncoder
+  alias ExProsemirror.Mark.{Color, Em, FontFamily, Link, Strikethrough, Strong, Underline}
+
+  describe "blocks" do
+    test "encode header" do
+      header =
+        %Heading{
+          content: [
+            %Text{text: "Hello folks"}
+          ],
+          attrs: %Heading.Attrs{level: 1}
+        }
+        |> HTMLEncoder.encode()
+        |> safe_to_string()
+
+      assert header == "<h1>Hello folks</h1>"
+    end
+
+    test "encode paragraph" do
+      paragraph =
+        %Paragraph{
+          content: [
+            %Text{text: "Hello folks"}
+          ]
+        }
+        |> HTMLEncoder.encode()
+        |> safe_to_string()
+
+      assert paragraph == "<p>Hello folks</p>"
+    end
+
+    test "encode image" do
+      img =
+        %Image{attrs: %Image.Attrs{src: "url", title: "title", alt: "An alt"}}
+        |> HTMLEncoder.encode()
+        |> safe_to_string()
+
+      assert img == ~s(<img alt="An alt" src="url">)
+    end
+
+    test "encode text" do
+      text = %Text{text: "Hello folks"} |> HTMLEncoder.encode() |> safe_to_string()
+      assert text == "Hello folks"
+    end
+
+    test "encode text with special chars" do
+      text = %Text{text: "<p>Hello folks</p>"} |> HTMLEncoder.encode() |> safe_to_string()
+      assert text == "&lt;p&gt;Hello folks&lt;/p&gt;"
+    end
+  end
+
+  describe "marks" do
+    test "em" do
+      text =
+        %Text{text: "Hello folks", marks: [%Em{}]} |> HTMLEncoder.encode() |> safe_to_string()
+
+      assert text == "<em>Hello folks</em>"
+    end
+
+    test "strong" do
+      text =
+        %Text{text: "Hello folks", marks: [%Strong{}]}
+        |> HTMLEncoder.encode()
+        |> safe_to_string()
+
+      assert text == "<strong>Hello folks</strong>"
+    end
+
+    test "em then strong" do
+      text =
+        %Text{text: "Hello folks", marks: [%Em{}, %Strong{}]}
+        |> HTMLEncoder.encode()
+        |> safe_to_string()
+
+      assert text == "<em><strong>Hello folks</strong></em>"
+    end
+
+    test "strong then em" do
+      text =
+        %Text{text: "Hello folks", marks: [%Strong{}, %Em{}]}
+        |> HTMLEncoder.encode()
+        |> safe_to_string()
+
+      assert text == "<strong><em>Hello folks</em></strong>"
+    end
+
+    test "strikethrough" do
+      text =
+        %Text{text: "Hello folks", marks: [%Strikethrough{}]}
+        |> HTMLEncoder.encode()
+        |> safe_to_string()
+
+      assert text == "<del>Hello folks</del>"
+    end
+
+    test "underline" do
+      text =
+        %Text{text: "Hello folks", marks: [%Underline{}]}
+        |> HTMLEncoder.encode()
+        |> safe_to_string()
+
+      assert text == ~s(<span style="text-decoration: underline;">Hello folks</span>)
+    end
+
+    test "color" do
+      text =
+        %Text{text: "Hello folks", marks: [%Color{attrs: %Color.Attrs{color: "red"}}]}
+        |> HTMLEncoder.encode()
+        |> safe_to_string()
+
+      assert text == ~s(<span style="color: red;">Hello folks</span>)
+    end
+
+    test "text family" do
+      text =
+        %Text{
+          text: "Hello folks",
+          marks: [%FontFamily{attrs: %FontFamily.Attrs{font_family: "sans-serif"}}]
+        }
+        |> HTMLEncoder.encode()
+        |> safe_to_string()
+
+      assert text == ~s(<span style="font-family: &quot;sans-serif;&quot;">Hello folks</span>)
+    end
+
+    test "link" do
+      href = "http://a-random-url.com/"
+
+      text =
+        %Text{
+          text: "Hello folks",
+          marks: [%Link{attrs: %Link.Attrs{title: "My link", href: href}}]
+        }
+        |> ExProsemirror.Encoder.HTML.encode()
+        |> safe_to_string()
+
+      assert text == ~s(<a href="#{href}">Hello folks</a>)
+    end
+  end
+end

--- a/test/html/form_test.exs
+++ b/test/html/form_test.exs
@@ -1,4 +1,4 @@
-defmodule ExProsemirror.FormTest do
+defmodule ExProsemirror.HTML.FormTest do
   use ExUnit.Case
 
   import Phoenix.HTML


### PR DESCRIPTION
## 📖 Description

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add html parser for ExProsemirror's blocks and marks.

Fixes # (issue)

## 📋 Type of change

<!-- Please delete options that are not relevant  -->


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
