### PR TITLE
⬆️ Migrate from `use Mix.Config`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,10 @@
-use Mix.Config
+import Config
 
 config :ex_prosemirror,
-  debug: false
+  debug: false,
+  env: config_env()
 
-if Mix.env() == :test do
+if config_env() == :test do
   config :ex_prosemirror,
     marks_modules: [
       em: ExProsemirror.Mark.Em,


### PR DESCRIPTION
## 📖 Description

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes this error message:

> warning: `use Mix.Config` is deprecated. Use the Config module instead
>   `config/config.exs:1`

## 📋 Type of change

<!-- Please delete options that are not relevant  -->

- [x] Bug fix (non-breaking change which fixes an issue)
