### PR TITLE
👥 Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Every file should be approved by at least 1 maintainer of the repo
+
+*.* @Omerlo-Technologies/maintainers


### PR DESCRIPTION
## 📖 Description

Add [`CODEOWNERS`](https://github.com/Omerlo-Technologies/omerlo-cms/blob/main/.github/CODEOWNERS)

This can only work if `@Omerlo-Technologies/maintainers` has write access to `Omerlo-Technologies/ex_prosemirror`. Please edit the configuration of the repository before merging.

## 📋 Type of change

